### PR TITLE
README: change travis badge with github actions one

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![dependency status](https://deps.rs/repo/github/lu-zero/cargo-c/status.svg)](https://deps.rs/repo/github/lu-zero/cargo-c)
 ![Crates.io](https://img.shields.io/crates/v/cargo-c.svg)
-[![Build Status](https://travis-ci.com/lu-zero/cargo-c.svg?branch=master)](https://travis-ci.com/lu-zero/cargo-c)
+[![Build Status](https://github.com/lu-zero/cargo-c/workflows/Rust/badge.svg)](https://github.com/lu-zero/cargo-c/actions?query=workflow:Rust)
 
 [cargo](https://doc.rust-lang.org/cargo) applet to build and install C-ABI compatibile dynamic and static libraries.
 


### PR DESCRIPTION
In commit c64eebd travis was removed, therefore the badge gives build error.
If you want a preview of how the new badge looks like go to my [README](https://github.com/MarcoIeni/cargo-c/blob/master/README.md)