### PR TITLE
cbuild: respect --version when called as subcommand

### DIFF
--- a/src/cbuild.rs
+++ b/src/cbuild.rs
@@ -59,6 +59,11 @@ fn main() -> CliResult {
         }
     };
 
+    if subcommand_args.is_present("version") {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     config_configure(&mut config, subcommand_args)?;
 
     let mut ws = subcommand_args.workspace(&config)?;


### PR DESCRIPTION
Not sure it's the right way to do that but should work too :)

Fix #62