### PR TITLE
Add dlltool argument

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -325,11 +325,7 @@ pub fn cbuild(
     if cur_hash.is_none() || prev_hash != cur_hash {
         build_def_file(&ws, &name, &rustc_target, &root_output)?;
 
-        let mut dlltool = PathBuf::from("dlltool");
-
-        if std::env::var_os("DLLTOOL").is_some() {
-            dlltool = PathBuf::from(std::env::var_os("DLLTOOL").unwrap());
-        }
+        let mut dlltool = std::env::var_os("DLLTOOL").unwrap_or_else(|| PathBuf::from("dlltool"));
 
         // dlltool argument overwrites environment var
         if args.value_of("dlltool").is_some() {

--- a/src/build.rs
+++ b/src/build.rs
@@ -175,7 +175,8 @@ fn build_implib_file(
             _ => unimplemented!("Windows support for {} is not implemented yet.", arch),
         };
 
-        let mut dlltool_command = std::process::Command::new(dlltool.to_str().unwrap_or_else(|| "dlltool"));
+        let mut dlltool_command =
+            std::process::Command::new(dlltool.to_str().unwrap_or_else(|| "dlltool"));
         dlltool_command.arg("-m").arg(binutils_arch);
         dlltool_command.arg("-D").arg(format!("{}.dll", name));
         dlltool_command
@@ -332,10 +333,7 @@ pub fn cbuild(
 
         // dlltool argument overwrites environment var
         if args.value_of("dlltool").is_some() {
-            dlltool = args
-                .value_of("dlltool")
-                .map(PathBuf::from)
-                .unwrap();
+            dlltool = args.value_of("dlltool").map(PathBuf::from).unwrap();
         }
 
         build_implib_file(&ws, &name, &rustc_target, &root_output, &dlltool)?;

--- a/src/build.rs
+++ b/src/build.rs
@@ -325,7 +325,9 @@ pub fn cbuild(
     if cur_hash.is_none() || prev_hash != cur_hash {
         build_def_file(&ws, &name, &rustc_target, &root_output)?;
 
-        let mut dlltool = std::env::var_os("DLLTOOL").unwrap_or_else(|| PathBuf::from("dlltool"));
+        let mut dlltool = std::env::var_os("DLLTOOL")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("dlltool"));
 
         // dlltool argument overwrites environment var
         if args.value_of("dlltool").is_some() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ struct Common {
     #[structopt(long = "pkgconfigdir", parse(from_os_str))]
     pkgconfigdir: Option<PathBuf>,
     #[structopt(long = "dlltool", parse(from_os_str))]
+    /// Use the provided dlltool when building for the windows-gnu targets.
     dlltool: Option<PathBuf>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,8 @@ struct Common {
     bindir: Option<PathBuf>,
     #[structopt(long = "pkgconfigdir", parse(from_os_str))]
     pkgconfigdir: Option<PathBuf>,
+    #[structopt(long = "dlltool", parse(from_os_str))]
+    dlltool: Option<PathBuf>,
 }
 
 pub fn base_cli() -> App<'static, 'static> {


### PR DESCRIPTION
Get dlltool command from environment variable DLLTOOL or command line argument --dlltool. If not specified default to "dlltool".

Fixes #87