### PR TITLE
Add optional min_version metadata to specify the minimum required cargo-c version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ your crates, read [Building Crates so they Look Like C ABI Libraries][dev.to].
 ## Advanced
 You may override various aspects of `cargo-c` via settings in `Cargo.toml` under the `package.metadata.capi` key
 
+```toml
+[package.metadata.capi]
+# Configures the minimum required cargo-c version. Trying to run with an
+# older version causes an error.
+min_version = "0.6.10"
+```
+
 ### Header Generation
 
 ```toml

--- a/src/build.rs
+++ b/src/build.rs
@@ -282,6 +282,22 @@ fn load_manifest_overrides(name: &str, root_path: &PathBuf) -> anyhow::Result<Ov
         .and_then(|v| v.get("metadata"))
         .and_then(|v| v.get("capi"));
 
+    if let Some(min_version) = capi
+        .as_ref()
+        .and_then(|capi| capi.get("min_version"))
+        .and_then(|v| v.as_str())
+    {
+        let min_version = Version::parse(min_version)?;
+        let version = Version::parse(env!("CARGO_PKG_VERSION"))?;
+        if min_version > version {
+            anyhow::bail!(
+                "Minimum required cargo-c version is {} but using cargo-c version {}",
+                min_version,
+                version
+            );
+        }
+    }
+
     let header = capi.and_then(|v| v.get("header"));
 
     let header = if let Some(ref capi) = capi {


### PR DESCRIPTION
Fixes https://github.com/lu-zero/cargo-c/issues/99

----

This is on top of https://github.com/lu-zero/cargo-c/pull/103