### PR TITLE
Fix CI binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,11 @@ jobs:
 
     - name: Create zip
       run: |
-        7z a cargo-c-windows-${{ matrix.conf }}.zip `
-             "target\release\cargo-capi.exe" `
-             "target\release\cargo-cbuild.exe" `
-             "target\release\cargo-cinstall.exe"
+        cd target/release
+        7z a ../../cargo-c-windows-${{ matrix.conf }}.zip `
+             "cargo-capi.exe" `
+             "cargo-cbuild.exe" `
+             "cargo-cinstall.exe"
 
     - name: Upload binaries
       uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,8 +97,9 @@ jobs:
     - name: Create zip
       run: |
         cd target/x86_64-unknown-linux-musl/release
-        strip cargo-cbuild cargo-cinstall
+        strip cargo-capi cargo-cbuild cargo-cinstall
         tar -czvf $GITHUB_WORKSPACE/cargo-c-linux.tar.gz \
+                  cargo-capi \
                   cargo-cbuild \
                   cargo-cinstall
 
@@ -129,8 +130,9 @@ jobs:
     - name: Create zip
       run: |
         cd target/release
-        strip cargo-cbuild cargo-cinstall
+        strip cargo-capi cargo-cbuild cargo-cinstall
         zip $GITHUB_WORKSPACE/cargo-c-macos.zip \
+            cargo-capi \
             cargo-cbuild \
             cargo-cinstall
 


### PR DESCRIPTION
- Add missing cargo-capi on linux/macos binary archive
- Remove target/release path on windows binary archive, to use the same file structure than other OSes.