### PR TITLE
CI: Use vendored OpenSSL for macOS release builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Build cargo-c
       run: |
-        cargo build --release
+        cargo build --features=cargo/vendored-openssl --release
 
     - name: Create zip
       run: |


### PR DESCRIPTION
This prevents the release builds to depend on just the right homebrew installed version of OpenSSL on the system running the binaries.