### PR TITLE
Add minimal example project (including CI)

### DIFF
--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -35,12 +35,12 @@ jobs:
         run: |
           cargo install --path .
 
-      - name: Set MSVC/dumpbin path
+      - name: Set MSVC binaries path
         if: matrix.toolchain-suffix == '-msvc'
         run: |
-          $MsvcPath = vswhere -latest -products * -find "VC\Tools\MSVC\*\bin\Hostx64\x64" |
-                      Select-Object -Last 1
-          echo "::add-path::$MsvcPath"
+          $BinGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+          $BinPath = vswhere -latest -products * -find "$BinGlob" | Select-Object -Last 1
+          echo "$BinPath" >> $GITHUB_PATH
 
       - name: Build example project
         working-directory: example-project

--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -35,13 +35,25 @@ jobs:
         run: |
           cargo install --path .
 
+      - name: Set MSVC/dumpbin path
+        if: matrix.toolchain-suffix == '-msvc'
+        run: |
+          $MsvcPath = vswhere -latest -products * -find "VC\Tools\MSVC\*\bin\Hostx64\x64" |
+                      Select-Object -Last 1
+          echo "::add-path::$MsvcPath"
+
       - name: Build example project
         working-directory: example-project
         run: |
           cargo cbuild --verbose --release
 
-      - name: Install example project
+      - name: Install into temporary location
         working-directory: example-project
         run: |
-          cargo cinstall --verbose --release --prefix=/usr/local --destdir=temp
+          cargo cinstall --verbose --release --destdir=temp
+
+      - name: Copy installed files to /usr/local
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+        working-directory: example-project
+        run: |
           sudo cp -r temp/usr/local/* /usr/local/

--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           $BinGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
           $BinPath = vswhere -latest -products * -find "$BinGlob" | Select-Object -Last 1
-          echo "$BinPath" >> $GITHUB_PATH
+          echo "$BinPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build example project
         working-directory: example-project

--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -39,6 +39,7 @@ jobs:
         if: matrix.toolchain-suffix == '-msvc'
         run: |
           $BinGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
           $BinPath = vswhere -latest -products * -find "$BinGlob" | Select-Object -Last 1
           echo "$BinPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -1,0 +1,47 @@
+name: Build example project
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+
+  example-project:
+
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+          - os: windows-latest
+            toolchain-suffix: -gnu
+          - os: windows-latest
+            toolchain-suffix: -msvc
+          - os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable${{ matrix.toolchain-suffix }}
+          override: true
+
+      - name: Install cargo-c applet
+        run: |
+          cargo install --path .
+
+      - name: Build example project
+        working-directory: example-project
+        run: |
+          cargo cbuild --verbose --release
+
+      - name: Install example project
+        working-directory: example-project
+        run: |
+          cargo cinstall --verbose --release --prefix=/usr/local --destdir=temp
+          sudo cp -r temp/usr/local/* /usr/local/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/example-project/target/

--- a/example-project/Cargo.toml
+++ b/example-project/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example-project"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+default = ["capi"]
+capi = ["libc"]
+
+[dependencies]
+libc = { version = "0.2", optional = true }

--- a/example-project/Cargo.toml
+++ b/example-project/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-default = ["capi"]
+default = []
 capi = ["libc"]
 
 [dependencies]

--- a/example-project/cbindgen.toml
+++ b/example-project/cbindgen.toml
@@ -1,0 +1,4 @@
+include_guard = "EXAMPLE_PROJECT_H"
+include_version = true
+language = "C"
+cpp_compat = true

--- a/example-project/src/capi.rs
+++ b/example-project/src/capi.rs
@@ -1,0 +1,11 @@
+use std::ffi::CStr;
+
+use libc::c_char;
+
+#[no_mangle]
+pub unsafe extern "C" fn example_project_hello(name: *const c_char) {
+    match CStr::from_ptr(name).to_str() {
+        Ok(name) => crate::hello(name),
+        Err(e) => eprintln!("Error: invalid name: {}", e),
+    }
+}

--- a/example-project/src/lib.rs
+++ b/example-project/src/lib.rs
@@ -1,0 +1,16 @@
+#![warn(rust_2018_idioms)]
+
+#[cfg(cargo_c)]
+mod capi;
+
+pub fn hello(name: &str) {
+    println!("Hello, {}!", name);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
I think it might be interesting to have an example project (or multiple?) as part of the docs.

On top of being just an example, this could also show how to use `cargo-c` via Github Actions.

The main reason I've made this PR is that there is an error when using MSVC:

```
    Building pkg-config file
    Building .def file using dumpbin
Error: CliError { error: Some(The system cannot find the file specified. (os error 2)), exit_code: 101 }
```

Does this mean that `dumpbin` is not available?
Or is the error talking about another file?

For now, this PR is a WIP because ~of the mentioned error, but also because~ I think it would make sense to add an example C program that uses the provided API.

Of course the example can be arbitrarily expanded, but for now I'm just trying to get a minimal example that compiles successfully on the targeted platforms.