### PR TITLE
Fix 'index out of bounds' in build.rs

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -407,7 +407,7 @@ pub fn cbuild(
     let targets = args.targets();
     let target = match targets.len() {
         0 => None,
-        1 => Some(targets[1].clone()),
+        1 => Some(targets[0].clone()),
         _ => {
             anyhow::bail!("Multiple targets not supported yet");
         }


### PR DESCRIPTION
I am getting the following error:

```
thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 1'
```

Looking at the code, it seems that if `targets.len()` is 1, then the first element should be `targets[0]` and not `targets[1]`.