### PR TITLE
example-project: Use #[cfg(cargo_c)] instead of #[cfg(feature = "capi")]

### DIFF
--- a/example-project/src/lib.rs
+++ b/example-project/src/lib.rs
@@ -7,7 +7,7 @@ Example library for [cargo-c].
 #![warn(rust_2018_idioms)]
 #![deny(missing_docs)]
 
-#[cfg(feature = "capi")]
+#[cfg(cargo_c)]
 mod capi;
 
 /// A counter for odd numbers.


### PR DESCRIPTION
... as suggested in the README.

I'm not sure what's the difference in the end, but I guess it's better to follow the suggestion from the README, right?