### PR TITLE
Add a simple way to set the RUSTFLAGS from Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ version = "1.2.3"
 install_subdir = "gstreamer-1.0"
 # Used to disable versioning links when installing the dynamic library
 versioning = false
+# Add `-Cpanic=abort` to the RUSTFLAGS automatically, it may be useful in case
+# something might panic in the crates used by the library.
+rustflags = "-Cpanic=abort"
 ```
 
 ## Users

--- a/example-project/Cargo.toml
+++ b/example-project/Cargo.toml
@@ -15,3 +15,6 @@ inline-c = "0.1"
 
 [package.metadata.capi.header]
 subdirectory = false
+
+[package.metadata.capi.library]
+rustflags = "-Cpanic=abort"

--- a/src/bin/capi.rs
+++ b/src/bin/capi.rs
@@ -67,6 +67,7 @@ fn main() -> CliResult {
     } else if cmd == "test" {
         ctest(
             &ws,
+            &capi_config,
             &config,
             subcommand_args,
             build_targets,

--- a/src/bin/ctest.rs
+++ b/src/bin/ctest.rs
@@ -40,11 +40,12 @@ fn main() -> CliResult {
 
     let mut ws = subcommand_args.workspace(&config)?;
 
-    let (build_targets, _, _, static_libs, compile_opts) =
+    let (build_targets, _, capi_config, static_libs, compile_opts) =
         cbuild(&mut ws, &config, &subcommand_args, "dev")?;
 
     ctest(
         &ws,
+        &capi_config,
         &config,
         subcommand_args,
         build_targets,

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -260,6 +260,8 @@ mod test {
                     version: Version::parse("0.1.0").unwrap(),
                     install_subdir: None,
                     versioning: true,
+                    rustflags: String::default(),
+                    original_rustflags: String::default(),
                 },
             },
         );


### PR DESCRIPTION
Fixes #172

Ideally I could try to add to `CompileOptions` a field and make so `TargetInfo::new` and `RustcTargetData::new` in cargo itself, but it might be too invasive for what seems to be needed only by us.

@sdroege Could you please test it and tell me if is working for you?