### PR TITLE
CI: test example project in Windows/MSYS2

### DIFF
--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -80,3 +80,29 @@ jobs:
         working-directory: example-project/usage-from-c
         run: |
           make
+
+      - name: Install into temporary location
+        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
+        working-directory: example-project
+        run: |
+          cargo cinstall --verbose --release --prefix=/mingw64 --destdir=temp
+
+      - name: Install MSYS2
+        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
+        uses: msys2/setup-msys2@v2
+        with:
+          release: false
+
+      - name: Copy installed files to /mingw64
+        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
+        working-directory: example-project
+        run: |
+          cp -r temp/mingw64/* /mingw64/
+        shell: msys2 {0}
+
+      - name: Test usage from C (using Makefile)
+        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
+        working-directory: example-project/usage-from-c
+        run: |
+          make
+        shell: msys2 {0}

--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -52,7 +52,6 @@ jobs:
           cargo ctest --verbose --release
 
       - name: Install into temporary location
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
         working-directory: example-project
         run: |
           cargo cinstall --verbose --release --destdir=temp
@@ -81,12 +80,6 @@ jobs:
         run: |
           make
 
-      - name: Install into temporary location
-        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
-        working-directory: example-project
-        run: |
-          cargo cinstall --verbose --release --prefix=/mingw64 --destdir=temp
-
       - name: Install MSYS2
         if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
         uses: msys2/setup-msys2@v2
@@ -97,7 +90,8 @@ jobs:
         if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
         working-directory: example-project
         run: |
-          cp -r temp/mingw64/* /mingw64/
+          # NB: --prefix doesn't seem to matter on Windows
+          cp -r temp/usr/local/* /mingw64/
         shell: msys2 {0}
 
       - name: Test usage from C (using Makefile)


### PR DESCRIPTION
This only seems to work with the GNU toolchain, which I guess makes sense.

I'm not an MSYS2 expert (in fact I've only ever used it on CI servers and I started very recently), so there might be a better way to do this.

It seems that `/usr/local/*` is not searched by default, I don't know why.