### PR TITLE
CI: use MSYS2 cargo package for example project

### DIFF
--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -80,26 +80,42 @@ jobs:
         run: |
           make
 
-      - name: Install MSYS2
-        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
-        uses: msys2/setup-msys2@v2
-        with:
-          release: false
-          update: true
-          install: >-
-            base-devel
+  example-project-msys2:
 
-      - name: Copy installed files
-        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
-        working-directory: example-project
-        run: |
-          # NB: --prefix doesn't seem to matter on Windows
-          cp -r temp/usr/local/{lib,bin,include} /mingw64/
+    runs-on: windows-latest
+    defaults:
+      run:
         shell: msys2 {0}
 
+    steps:
+      - name: Clone Git repository
+        uses: actions/checkout@v2
+
+      - name: Install MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          install: >-
+            make
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-rust
+      #      mingw-w64-x86_64-cargo-c
+
+      # NB: cargo-c is available from the package mingw-w64-x86_64-cargo-c
+      # (https://packages.msys2.org/base/mingw-w64-cargo-c),
+      # which is the recommended way to use cargo-c on MSYS2.
+      # For testing purposes, we compile and install the latest version from the Git repo
+      # (which takes much longer than installing the MSYS2 package!):
+
+      - name: Install cargo-c applet
+        run: |
+          cargo install --path .
+
+      - name: Install C API for example project
+        working-directory: example-project
+        run: |
+          cargo cinstall --verbose --release --prefix /mingw64 --target x86_64-pc-windows-gnu
+
       - name: Test usage from C (using Makefile)
-        if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
         working-directory: example-project/usage-from-c
         run: |
           make
-        shell: msys2 {0}


### PR DESCRIPTION
I recently found out that there is a Rust package for MSYS2 (https://packages.msys2.org/base/mingw-w64-rust), and there is even a package for `cargo-c` (https://packages.msys2.org/base/mingw-w64-cargo-c)!

I tried to use the Rust package on CI, but still compile the latest version of `cargo-c` on the fly.

Sadly, there are a few problems ...

Currently, there is a build error during `cargo cinstall`, any ideas how to fix this?

After that, there might still be a problem with the library not being installed into the default location normally used for MSYS2, but for now that's blocked by the compilation error.

~There seems to be another error in the Windows build (the one without MSYS2), which should also be solved, but it isn't really related to this PR.~