### PR TITLE
Support iOS in install.rs

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -89,7 +89,7 @@ impl LibType {
 
         match (os.as_str(), env.as_str()) {
             ("linux", _) | ("freebsd", _) | ("dragonfly", _) | ("netbsd", _) => LibType::So,
-            ("macos", _) => LibType::Dylib,
+            ("macos", _) | ("ios", _) => LibType::Dylib,
             ("windows", _) => LibType::Windows,
             _ => unimplemented!("The target {}-{} is not supported yet", os, env),
         }


### PR DESCRIPTION
Should fix an error I encountered cross compiling rav1e.
```
    Finished release [optimized + debuginfo] target(s) in 35.48s
    Building pkg-config files
    Building header file using cbindgen
thread 'main' panicked at 'not implemented: The target ios- is not supported yet', /Users/diatrus/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-c-0.8.1+cargo-0.53/src/install.rs:94:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
gmake[1]: *** [rav1e.mk:18: rav1e] Error 101
gmake: *** [Makefile:935: rebuild-rav1e] Error 2
```