### PR TITLE
Prepare for cargo 0.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ name = "cargo-ctest"
 path = "src/bin/ctest.rs"
 
 [dependencies]
-cargo = "0.53"
-semver = "0.10"
+cargo = "0.55"
+cargo-util = "0.1"
+semver = "1.0"
 log = "0.4"
 structopt = { version="0.3", features=["color"] }
 regex = "1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -9,7 +9,6 @@ use cargo::core::{compiler::Executor, profiles::Profiles};
 use cargo::core::{TargetKind, Workspace};
 use cargo::ops::{self, CompileFilter, CompileOptions, FilterRule, LibRule};
 use cargo::util::command_prelude::{ArgMatches, ArgMatchesExt, CompileMode, ProfileChecking};
-use cargo::util::errors;
 use cargo::{CliError, CliResult, Config};
 
 use anyhow::Error;
@@ -143,7 +142,9 @@ fn patch_capi_feature(compile_opts: &mut CompileOptions, ws: &Workspace) -> anyh
     let manifest = pkg.manifest();
 
     if manifest.summary().features().get("capi").is_some() {
-        compile_opts.features.push("capi".to_string());
+        std::rc::Rc::get_mut(&mut compile_opts.cli_features.features)
+            .unwrap()
+            .insert(FeatureValue::new("capi".into()));
     }
 
     Ok(())
@@ -586,8 +587,8 @@ struct Exec {
 }
 
 use cargo::core::*;
-use cargo::util::ProcessBuilder;
 use cargo::CargoResult;
+use cargo_util::{is_simple_exit_code, ProcessBuilder};
 
 impl Executor for Exec {
     fn exec(
@@ -862,7 +863,7 @@ pub fn ctest(
             let context = anyhow::format_err!("{}", err.hint(&ws, &ops.compile_opts));
             let e = match err.code {
                 // Don't show "process didn't exit successfully" for simple errors.
-                Some(i) if errors::is_simple_exit_code(i) => CliError::new(context, i),
+                Some(i) if is_simple_exit_code(i) => CliError::new(context, i),
                 Some(i) => CliError::new(Error::from(err).context(context), i),
                 None => CliError::new(Error::from(err).context(context), 101),
             };


### PR DESCRIPTION
Notable changes:
- cli_features is a new struct
- some functionality got spun off in a `cargo-util` crate