### PR TITLE
Make the applets able to forward calls to other applets

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -7,8 +7,19 @@ cargo build
 cargo test
 unset RUSTFLAGS
 
+target/debug/cargo-capi capi --help
 target/debug/cargo-capi capi test --manifest-path=example-project/Cargo.toml
+target/debug/cargo-capi capi clean --manifest-path=example-project/Cargo.toml
 target/debug/cargo-capi capi build --manifest-path=example-project/Cargo.toml
+
+target/debug/cargo-cbuild --help
+target/debug/cargo-cbuild clean --manifest-path=example-project/Cargo.toml
+target/debug/cargo-cbuild cbuild --manifest-path=example-project/Cargo.toml
+target/debug/cargo-ctest metadata --help
+target/debug/cargo-ctest ctest --manifest-path=example-project/Cargo.toml
+
+target/debug/cargo-cinstall --help
 target/debug/cargo-cinstall cinstall --manifest-path=example-project/Cargo.toml --destdir=/tmp/staging
+target/debug/cargo-cinstall cinstall clean --manifest-path=example-project/Cargo.toml
 
 grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov

--- a/example-project/Cargo.toml
+++ b/example-project/Cargo.toml
@@ -13,6 +13,9 @@ libc = { version = "0.2", optional = true }
 [dev-dependencies]
 inline-c = "0.1"
 
+[build-dependencies]
+cargo_metadata = "0.13.1"
+
 [package.metadata.capi.header]
 subdirectory = false
 

--- a/example-project/build.rs
+++ b/example-project/build.rs
@@ -1,0 +1,12 @@
+use cargo_metadata::*;
+
+fn main() {
+    let path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let meta = MetadataCommand::new()
+        .manifest_path("./Cargo.toml")
+        .current_dir(&path)
+        .exec()
+        .unwrap();
+
+    println!("{:?}", meta);
+}

--- a/src/bin/capi.rs
+++ b/src/bin/capi.rs
@@ -21,6 +21,7 @@ fn main() -> CliResult {
             AppSettings::UnifiedHelpMessage,
             AppSettings::DeriveDisplayOrder,
             AppSettings::VersionlessSubcommands,
+            AppSettings::AllowExternalSubcommands,
         ])
         .subcommand(
             SubCommand::with_name("capi")
@@ -38,6 +39,9 @@ fn main() -> CliResult {
             ("build", Some(args)) => ("build", args, "dev"),
             ("test", Some(args)) => ("test", args, "dev"),
             ("install", Some(args)) => ("install", args, "release"),
+            (cmd, Some(args)) => {
+                return run_cargo_fallback(cmd, args);
+            }
             _ => {
                 // No subcommand provided.
                 app.print_help()?;

--- a/src/bin/cbuild.rs
+++ b/src/bin/cbuild.rs
@@ -3,6 +3,7 @@ use cargo::CliResult;
 use cargo::Config;
 
 use cargo_c::build::*;
+use cargo_c::cli::run_cargo_fallback;
 use cargo_c::cli::subcommand_build;
 
 use structopt::clap::*;
@@ -17,6 +18,7 @@ fn main() -> CliResult {
             AppSettings::UnifiedHelpMessage,
             AppSettings::DeriveDisplayOrder,
             AppSettings::VersionlessSubcommands,
+            AppSettings::AllowExternalSubcommands,
         ])
         .subcommand(subcommand);
 
@@ -24,6 +26,9 @@ fn main() -> CliResult {
 
     let subcommand_args = match args.subcommand() {
         ("cbuild", Some(args)) => args,
+        (cmd, Some(args)) => {
+            return run_cargo_fallback(cmd, args);
+        }
         _ => {
             // No subcommand provided.
             app.print_help()?;

--- a/src/bin/cinstall.rs
+++ b/src/bin/cinstall.rs
@@ -3,6 +3,7 @@ use cargo::CliResult;
 use cargo::Config;
 
 use cargo_c::build::{cbuild, config_configure};
+use cargo_c::cli::run_cargo_fallback;
 use cargo_c::cli::subcommand_install;
 use cargo_c::install::cinstall;
 
@@ -17,6 +18,7 @@ fn main() -> CliResult {
             AppSettings::UnifiedHelpMessage,
             AppSettings::DeriveDisplayOrder,
             AppSettings::VersionlessSubcommands,
+            AppSettings::AllowExternalSubcommands,
         ])
         .subcommand(subcommand);
 
@@ -24,6 +26,9 @@ fn main() -> CliResult {
 
     let subcommand_args = match args.subcommand() {
         ("cinstall", Some(args)) => args,
+        (cmd, Some(args)) => {
+            return run_cargo_fallback(cmd, args);
+        }
         _ => {
             // No subcommand provided.
             app.print_help()?;

--- a/src/bin/ctest.rs
+++ b/src/bin/ctest.rs
@@ -3,6 +3,7 @@ use cargo::CliResult;
 use cargo::Config;
 
 use cargo_c::build::*;
+use cargo_c::cli::run_cargo_fallback;
 use cargo_c::cli::subcommand_test;
 
 use structopt::clap::*;
@@ -17,6 +18,7 @@ fn main() -> CliResult {
             AppSettings::UnifiedHelpMessage,
             AppSettings::DeriveDisplayOrder,
             AppSettings::VersionlessSubcommands,
+            AppSettings::AllowExternalSubcommands,
         ])
         .subcommand(subcommand);
 
@@ -24,6 +26,9 @@ fn main() -> CliResult {
 
     let subcommand_args = match args.subcommand() {
         ("ctest", Some(args)) => args,
+        (cmd, Some(args)) => {
+            return run_cargo_fallback(cmd, args);
+        }
         _ => {
             // No subcommand provided.
             app.print_help()?;

--- a/src/build.rs
+++ b/src/build.rs
@@ -911,6 +911,15 @@ pub fn ctest(
     }
 }
 
+// Take the original cargo instance and save it as a separate env var if not already set.
+fn setup_env() {
+    if env::var("CARGO_C_CARGO").is_err() {
+        let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+
+        std::env::set_var("CARGO_C_CARGO", cargo);
+    }
+}
+
 pub fn config_configure(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let arg_target_dir = &args.value_of_path("target-dir", config);
     let config_args: Vec<_> = args
@@ -931,5 +940,8 @@ pub fn config_configure(config: &mut Config, args: &ArgMatches<'_>) -> CliResult
             .unwrap_or_default(),
         &config_args,
     )?;
+
+    // Make sure that the env-vars are correctly set at this point.
+    setup_env();
     Ok(())
 }


### PR DESCRIPTION
This fixes crates using `cargo metadata` in build.rs due to how `cargo_exe()` is working.