### PR TITLE
Include path options

### DIFF
--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -66,7 +66,7 @@ jobs:
         if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
         run: |
           set -x
-          test "$(pkg-config --cflags example_project)" = "-I/usr/local/include"
+          test "$(pkg-config --cflags example_project)" = "-I/usr/local/include/example-project-0.1"
           test "$(pkg-config --libs example_project)" = "-L/usr/local/lib -lexample-project"
 
       - name: Update dynamic linker cache
@@ -86,12 +86,13 @@ jobs:
         with:
           release: false
 
-      - name: Copy installed files to /mingw64
+      - name: Copy installed files
         if: startsWith(matrix.os, 'windows') && matrix.toolchain-suffix == '-gnu'
         working-directory: example-project
         run: |
           # NB: --prefix doesn't seem to matter on Windows
-          cp -r temp/usr/local/* /mingw64/
+          cp -r temp/usr/local/include /usr/local/
+          cp -r temp/usr/local/{lib,bin} /mingw64/
         shell: msys2 {0}
 
       - name: Test usage from C (using Makefile)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ enabled = true
 [package.metadata.capi.pkg_config]
 # Used as the package name in the pkg-config file and defaults to the crate name.
 name = "libfoo"
+# Used as the pkg-config file name and defaults to the crate name.
+filename = "libfoo-2.0"
 # Used as the package description in the pkg-config file and defaults to the crate description.
 description = "some description"
 # Used as the package version in the pkg-config file and defaults to the crate version.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ min_version = "0.6.10"
 # The name can be with or without the header filename extension `.h`
 name = "new_name"
 # Install the header into a subdirectory with the name of the crate. This
-# is enabled by default
-subdirectory = true
+# is enabled by default, pass `false` or "" to disable it.
+subdirectory = "libfoo-2.0/foo"
 # Generate the header file with `cbindgen`, or copy a pre-generated header
 # from the `assets` subdirectory. By default a header is generated.
 generation = true

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ version = "1.2.3"
 requires = "gstreamer-1.0, gstreamer-base-1.0"
 # Used as the Requires.private field in the pkg-config file, if defined
 requires_private = "gobject-2.0, glib-2.0 >= 2.56.0, gmodule-2.0"
+# Strip the include search path from the last n components, useful to support installing in a
+# subdirectory but then include with the path. By default it is 0.
+strip_include_path_components = 1
+
 ```
 
 ### Library Generation

--- a/example-project/Cargo.toml
+++ b/example-project/Cargo.toml
@@ -17,7 +17,10 @@ inline-c = "0.1"
 cargo_metadata = "0.13.1"
 
 [package.metadata.capi.header]
-subdirectory = false
+subdirectory = "example-project-0.1/example_project"
+
+[package.metadata.capi.pkg_config]
+strip_include_path_components = 1
 
 [package.metadata.capi.library]
 rustflags = "-Cpanic=abort"

--- a/example-project/usage-from-c/Makefile
+++ b/example-project/usage-from-c/Makefile
@@ -1,4 +1,5 @@
 LDLIBS = -lexample-project
+CFLAGS = -I/usr/local/include/example-project-0.1
 
 test: run_tests
 	./run_tests

--- a/example-project/usage-from-c/run_tests.c
+++ b/example-project/usage-from-c/run_tests.c
@@ -1,4 +1,4 @@
-#include <example_project.h>
+#include "example_project/example_project.h"
 #include <stdio.h>
 
 int main() {

--- a/src/build.rs
+++ b/src/build.rs
@@ -421,6 +421,7 @@ pub struct PkgConfigCApiConfig {
     pub version: String,
     pub requires: Option<String>,
     pub requires_private: Option<String>,
+    pub strip_include_path_components: usize,
 }
 
 pub struct LibraryCApiConfig {
@@ -524,6 +525,7 @@ fn load_manifest_capi_config(
     let mut version = pkg.version().to_string();
     let mut requires = None;
     let mut requires_private = None;
+    let mut strip_include_path_components = 0;
 
     if let Some(ref pc) = pc {
         if let Some(override_name) = pc.get("name").and_then(|v| v.as_str()) {
@@ -544,6 +546,10 @@ fn load_manifest_capi_config(
         if let Some(req) = pc.get("requires_private").and_then(|v| v.as_str()) {
             requires_private = Some(String::from(req));
         }
+        strip_include_path_components = pc
+            .get("strip_include_path_components")
+            .map(|v| v.clone().try_into())
+            .unwrap_or_else(|| Ok(0))?
     }
 
     let pkg_config = PkgConfigCApiConfig {
@@ -553,6 +559,7 @@ fn load_manifest_capi_config(
         version,
         requires,
         requires_private,
+        strip_include_path_components,
     };
 
     let library = capi.and_then(|v| v.get("library"));

--- a/src/install.rs
+++ b/src/install.rs
@@ -184,10 +184,8 @@ pub fn cinstall(
 
     let install_path_lib = append_to_destdir(destdir, &install_path_lib);
     let install_path_pc = append_to_destdir(destdir, &paths.pkgconfigdir);
-    let mut install_path_include = append_to_destdir(destdir, &paths.includedir);
-    if let Some(name) = paths.subdir_name {
-        install_path_include = install_path_include.join(name);
-    }
+    let install_path_include =
+        append_to_destdir(destdir, &paths.includedir).join(&paths.subdir_name);
 
     fs::create_dir_all(&install_path_lib)?;
     fs::create_dir_all(&install_path_pc)?;
@@ -250,7 +248,7 @@ pub fn cinstall(
 
 #[derive(Debug, Hash)]
 pub struct InstallPaths {
-    pub subdir_name: Option<PathBuf>,
+    pub subdir_name: PathBuf,
     pub destdir: PathBuf,
     pub prefix: PathBuf,
     pub libdir: PathBuf,
@@ -260,7 +258,7 @@ pub struct InstallPaths {
 }
 
 impl InstallPaths {
-    pub fn new(name: &str, args: &ArgMatches<'_>, capi_config: &CApiConfig) -> Self {
+    pub fn new(_name: &str, args: &ArgMatches<'_>, capi_config: &CApiConfig) -> Self {
         let destdir = args
             .value_of("destdir")
             .map(PathBuf::from)
@@ -277,11 +275,8 @@ impl InstallPaths {
             .value_of("includedir")
             .map(PathBuf::from)
             .unwrap_or_else(|| prefix.join("include"));
-        let subdir_name = if capi_config.header.subdirectory {
-            Some(PathBuf::from(name))
-        } else {
-            None
-        };
+        let subdir_name = PathBuf::from(&capi_config.header.subdirectory);
+
         let bindir = args
             .value_of("bindir")
             .map(PathBuf::from)

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -41,7 +41,7 @@ impl PkgConfig {
     /// Cflags: -I${includedir}/$name
     /// Libs: -L${libdir} -l$name
     ///
-    pub fn new(name: &str, capi_config: &CApiConfig) -> Self {
+    pub fn new(_name: &str, capi_config: &CApiConfig) -> Self {
         let requires = match &capi_config.pkg_config.requires {
             Some(reqs) => reqs.split(',').map(|s| s.trim().to_string()).collect(),
             _ => Vec::new(),
@@ -63,11 +63,10 @@ impl PkgConfig {
         ];
 
         let cflags = if capi_config.header.enabled {
-            if capi_config.header.subdirectory {
-                format!("-I{}/{}", "${includedir}", name)
-            } else {
-                String::from("-I${includedir}")
-            }
+            let mut includedir = PathBuf::from("${includedir}");
+            includedir.push(&capi_config.header.subdirectory);
+
+            format!("-I{}", includedir.display())
         } else {
             String::from("")
         };
@@ -244,7 +243,7 @@ mod test {
             &CApiConfig {
                 header: crate::build::HeaderCApiConfig {
                     name: "foo".into(),
-                    subdirectory: true,
+                    subdirectory: "".into(),
                     generation: true,
                     enabled: true,
                 },

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -64,7 +64,11 @@ impl PkgConfig {
 
         let cflags = if capi_config.header.enabled {
             let mut includedir = PathBuf::from("${includedir}");
-            includedir.push(&capi_config.header.subdirectory);
+            let subdirectory = Path::new(&capi_config.header.subdirectory)
+                .ancestors()
+                .nth(capi_config.pkg_config.strip_include_path_components)
+                .unwrap_or_else(|| Path::new(""));
+            includedir.push(&subdirectory);
 
             format!("-I{}", includedir.display())
         } else {
@@ -254,6 +258,7 @@ mod test {
                     version: "0.1".into(),
                     requires: Some("somelib, someotherlib".into()),
                     requires_private: Some("someprivatelib >= 1.0".into()),
+                    strip_include_path_components: 0,
                 },
                 library: crate::build::LibraryCApiConfig {
                     name: "foo".into(),


### PR DESCRIPTION
It should manage to tackle the remaining peculiarities mentioned in https://github.com/lu-zero/cargo-c/issues/204.

The additional install support being worked on will make possible to install multiple headers.