### PR TITLE
Support custom pre-generated and generated include

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ serde_derive = "1.0"
 serde_json = "1.0.62"
 anyhow = "1.0"
 cc = "1.0"
-
+glob = "0.3"
+itertools = "0.10"
 
 [features]
 default = []

--- a/example-project/Cargo.toml
+++ b/example-project/Cargo.toml
@@ -25,3 +25,7 @@ strip_include_path_components = 1
 [package.metadata.capi.library]
 rustflags = "-Cpanic=abort"
 name = "example-project"
+
+[package.metadata.capi.install.include]
+asset = [{from = "include/file.h", to = "otherplace" }]
+generated = [{from = "include/other_file.h", to = "otherplace" }]

--- a/example-project/build.rs
+++ b/example-project/build.rs
@@ -1,4 +1,5 @@
 use cargo_metadata::*;
+use std::path::*;
 
 fn main() {
     let path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -9,4 +10,19 @@ fn main() {
         .unwrap();
 
     println!("{:?}", meta);
+
+    let out = std::env::var("OUT_DIR").unwrap();
+    let out = Path::new(&out);
+
+    let path = out.join("capi/include/");
+    let subdir = path.join("subdir");
+    let include = out.join("include");
+
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::create_dir_all(&include).unwrap();
+
+    std::fs::write(path.join("generated.h"), "// Generated").unwrap();
+    std::fs::write(subdir.join("in_subdir.h"), "// Generated").unwrap();
+    std::fs::write(include.join("other_file.h"), "// Generated").unwrap();
 }

--- a/src/build_targets.rs
+++ b/src/build_targets.rs
@@ -13,7 +13,7 @@ impl ExtraTargets {
         &mut self,
         capi_config: &CApiConfig,
         root_dir: &Path,
-        out_dir: &Path,
+        out_dir: Option<&Path>,
     ) -> anyhow::Result<()> {
         self.include = extra_targets(&capi_config.install.include, root_dir, out_dir)?;
 
@@ -24,14 +24,16 @@ impl ExtraTargets {
 fn extra_targets(
     targets: &[InstallTarget],
     root_path: &Path,
-    root_output: &Path,
+    root_output: Option<&Path>,
 ) -> anyhow::Result<Vec<(PathBuf, PathBuf)>> {
     use itertools::*;
     targets
         .iter()
-        .map(|t| match t {
-            InstallTarget::Asset(paths) => paths.install_paths(root_path),
-            InstallTarget::Generated(paths) => paths.install_paths(root_output),
+        .filter_map(|t| match t {
+            InstallTarget::Asset(paths) => Some(paths.install_paths(root_path)),
+            InstallTarget::Generated(paths) => {
+                root_output.map(|root_output| paths.install_paths(root_output))
+            }
         })
         .flatten_ok()
         .collect()

--- a/src/install.rs
+++ b/src/install.rs
@@ -198,20 +198,12 @@ pub fn cinstall(
     )?;
 
     if capi_config.header.enabled {
-        let install_path_include = install_path_include.join(&paths.subdir_name);
-        fs::create_dir_all(&install_path_include)?;
         ws.config().shell().status("Installing", "header file")?;
-        let include = &build_targets.include.clone().unwrap();
-        fs::copy(
-            include,
-            install_path_include.join(include.file_name().unwrap()),
-        )?;
-    }
-
-    for (from, to) in build_targets.extra.include.iter() {
-        let to = install_path_include.join(to);
-        fs::create_dir_all(to.parent().unwrap())?;
-        copy(from, to)?;
+        for (from, to) in build_targets.extra.include.iter() {
+            let to = install_path_include.join(to);
+            fs::create_dir_all(to.parent().unwrap())?;
+            copy(from, to)?;
+        }
     }
 
     if let Some(ref static_lib) = build_targets.static_lib {

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -147,10 +147,6 @@ impl PkgConfig {
         uninstalled.libdir = "${prefix}".into();
         // First libs item is the search path
         uninstalled.libs[0] = "-L${prefix}".into();
-        // First cflags item is the in include dir, if lib provides headers
-        if uninstalled.cflags[0].starts_with("-I") {
-            uninstalled.cflags[0] = "-I{prefix}".into();
-        }
 
         uninstalled
     }

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -291,6 +291,9 @@ mod test {
                     versioning: true,
                     rustflags: Vec::default(),
                 },
+                install: crate::build::InstallCApiConfig {
+                    include: Vec::new(),
+                },
             },
         );
         pkg.add_lib("-lbar").add_cflag("-DFOO");


### PR DESCRIPTION
- [x] The default patterns are `{root_dir}/assets/capi/include/**/*` and `{out_dir}/capi/include/**/*`.
- [x] Custom patterns support