### PR TITLE
Add support for Haiku Operating System

### DIFF
--- a/src/build_targets.rs
+++ b/src/build_targets.rs
@@ -81,7 +81,8 @@ impl BuildTargets {
             | ("freebsd", _)
             | ("dragonfly", _)
             | ("netbsd", _)
-            | ("android", _) => {
+            | ("android", _)
+            | ("haiku", _) => {
                 let static_lib = targetdir.join(&format!("lib{}.a", lib_name));
                 let shared_lib = targetdir.join(&format!("lib{}.so", lib_name));
                 (shared_lib, static_lib, None, None)

--- a/src/install.rs
+++ b/src/install.rs
@@ -84,9 +84,12 @@ impl LibType {
         let env = &target.env;
 
         match (os.as_str(), env.as_str()) {
-            ("linux", _) | ("freebsd", _) | ("dragonfly", _) | ("netbsd", _) | ("android", _) => {
-                LibType::So
-            }
+            ("linux", _)
+            | ("freebsd", _)
+            | ("dragonfly", _)
+            | ("netbsd", _)
+            | ("android", _)
+            | ("haiku", _) => LibType::So,
             ("macos", _) | ("ios", _) => LibType::Dylib,
             ("windows", _) => LibType::Windows,
             _ => unimplemented!("The target {}-{} is not supported yet", os, env),

--- a/src/target.rs
+++ b/src/target.rs
@@ -72,7 +72,11 @@ impl Target {
         if os == "android" {
             lines.push(format!("-Wl,-soname,lib{}.so", lib_name));
         } else if env != "musl"
-            && (os == "linux" || os == "freebsd" || os == "dragonfly" || os == "netbsd")
+            && (os == "linux"
+                || os == "freebsd"
+                || os == "dragonfly"
+                || os == "netbsd"
+                || os == "haiku")
         {
             lines.push(format!("-Wl,-soname,lib{}.so.{}", lib_name, major));
         } else if os == "macos" || os == "ios" {


### PR DESCRIPTION
For now I've used this to build cargo-c version 0.9.8 (later version contains an error when using latest libgit2-sys), see: https://github.com/haikuports/haikuports/pull/5534
Also have been able to build rav1e 0.5.1 with this.

![rav1e](https://user-images.githubusercontent.com/16057090/172016994-082740a6-ecbd-43d9-b618-e99a1fc773c3.png)
