### PR TITLE
Add sonames on musl

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -71,12 +71,11 @@ impl Target {
 
         if os == "android" {
             lines.push(format!("-Wl,-soname,lib{}.so", lib_name));
-        } else if env != "musl"
-            && (os == "linux"
-                || os == "freebsd"
-                || os == "dragonfly"
-                || os == "netbsd"
-                || os == "haiku")
+        } else if os == "linux"
+            || os == "freebsd"
+            || os == "dragonfly"
+            || os == "netbsd"
+            || os == "haiku"
         {
             lines.push(format!("-Wl,-soname,lib{}.so.{}", lib_name, major));
         } else if os == "macos" || os == "ios" {


### PR DESCRIPTION
the musl platform also supports shared objects having an SONAME, and
this function is called only when making a 'shared object', so this
should always be added

fixes https://github.com/lu-zero/cargo-c/commit/04a92bc497698cc822bc969307744eb929cc1eab where this was removed
even when generating a dynamic library forcefully by setting library
type to cdylib

fixes https://github.com/lu-zero/cargo-c/issues/267