### PR TITLE
Fix linking with Android NDK linker

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -70,7 +70,7 @@ impl Target {
         let env = &self.env;
 
         if os == "android" {
-            lines.push(format!("-Wl,-soname,lib{}.so", lib_name));
+            lines.push(format!("-soname,lib{}.so", lib_name));
         } else if os == "linux"
             || os == "freebsd"
             || os == "dragonfly"


### PR DESCRIPTION
Android NDK `ld.gold` cannot handle `-Wl`, and it's incorrect anyway since all the other linker arguments passed by cargo do not have a `-Wl` prefix.

```
<lots of args snipped> "--gc-sections" "-shared" "-zrelro" "-znow" "-O1" "-Wl,-soname,libgsturiplaylistbin.so"
   = note: arm-linux-androideabi-ld.gold: -Wl,-soname,libgsturiplaylistbin.so: unknown option
           arm-linux-androideabi-ld.gold: use the --help option for usage information
```