### PR TITLE
ci(deploy): Use musl abi for aarch64 linux binary, add i686 linux

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,19 +32,11 @@ jobs:
 
     - name: Build cargo-c
       run: |
-        cargo build --release
-
-    - name: Strip gnu binaries
-      if: matrix.conf == 'gnu'
-      run: |
-        strip "target\release\cargo-capi.exe" `
-              "target\release\cargo-cbuild.exe" `
-              "target\release\cargo-cinstall.exe"
-
+        cargo build --profile release-strip
 
     - name: Create zip
       run: |
-        cd target/release
+        cd target/release-strip
         7z a ../../cargo-c-windows-${{ matrix.conf }}.zip `
              "cargo-capi.exe" `
              "cargo-cbuild.exe" `
@@ -82,11 +74,13 @@ jobs:
 
     - name: Build cargo-c
       run: |
-        cross build --target ${{ matrix.target }} --features=vendored-openssl --release
+        cross build --target ${{ matrix.target }} \
+          --features=vendored-openssl \
+          --profile release-strip
 
     - name: Create zip
       run: |
-        cd target/${{ matrix.target }}/release
+        cd target/${{ matrix.target }}/release-strip
         tar -czvf $GITHUB_WORKSPACE/cargo-c-${{ matrix.target }}.tar.gz \
                   cargo-capi \
                   cargo-cbuild \
@@ -112,12 +106,11 @@ jobs:
 
     - name: Build cargo-c
       run: |
-        cargo build --features=vendored-openssl --release
+        cargo build --features=vendored-openssl --profile release-strip
 
     - name: Create zip
       run: |
-        cd target/release
-        strip cargo-capi cargo-cbuild cargo-cinstall
+        cd target/release-strip
         zip $GITHUB_WORKSPACE/cargo-c-macos.zip \
             cargo-capi \
             cargo-cbuild \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,43 +58,31 @@ jobs:
 
   linux-binaries:
     strategy:
+      fail-fast: false
       matrix:
         target:
+         - i686-unknown-linux-musl
          - x86_64-unknown-linux-musl
          - powerpc64le-unknown-linux-gnu
-         - aarch64-unknown-linux-gnu
-        include:
-         - target: x86_64-unknown-linux-musl
-           sdk: musl-tools
-           cc: cc
-         - target: powerpc64le-unknown-linux-gnu
-           sdk: crossbuild-essential-ppc64el
-           cc: powerpc64le-linux-gnu-gcc
-         - target: aarch64-unknown-linux-gnu
-           sdk: crossbuild-essential-arm64
-           cc: aarch64-linux-gnu-gcc
+         - aarch64-unknown-linux-musl
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install $${{ matrix.sdk }}
-      run: |
-        sudo apt-get install ${{ matrix.sdk }}
-
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        target: ${{ matrix.target }}
+
+    - name: Install cross
+      run: |
+        cargo install cross --git https://github.com/cross-rs/cross
 
     - name: Build cargo-c
       run: |
-        mkdir .cargo
-        echo -e "[target.${{ matrix.target }}]\nlinker=\"${{ matrix.cc }}\"\n" > .cargo/config
-        echo -e "[profile.release]\nstrip = true" >> .cargo/config
-        cargo build --target ${{ matrix.target }} --release --features vendored-openssl
+        cross build --target ${{ matrix.target }} --features=vendored-openssl --release
 
     - name: Create zip
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ itertools = "0.10"
 [features]
 default = []
 vendored-openssl = ["cargo/vendored-openssl"]
+
+[profile.release]
+strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,6 @@ itertools = "0.10"
 default = []
 vendored-openssl = ["cargo/vendored-openssl"]
 
-[profile.release]
+[profile.release-strip]
+inherits = "release"
 strip = "symbols"


### PR DESCRIPTION
I'm using cross to build a binary for the aarch64-unknown-linux-musl target, which avoids glibc ABI compatibility issues with the gcc from crossbuild-essential-arm64 and so can run on more platforms. I've also added i686 linux musl binaries to the deploy workflow. The binary created by aarch64-unknown-linux-gnu only runs on the most recent distributions because of the version of glibc it is linked against. Executing the binaries from the v0.9.14-deploy release on debian buster (and el7) fails with the error:

```
cargo-cinstall: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by cargo-cinstall)
cargo-cinstall: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by cargo-cinstall)
```

I've created a test release on my fork [here](https://github.com/fdintino/cargo-c/releases/tag/v0.9.14-musl-aarch64-i686). I've also written a workflow job to test that the binaries can run against debian buster, but omitted it from this PR because I wasn't sure it was worth the added complexity. Still, you can see it in [this commit](https://github.com/fdintino/cargo-c/commit/97c15b167658cf8ab657e9dffacea2e4a6251979), and its run against the binaries built from this PR [here](https://github.com/fdintino/cargo-c/actions/runs/3436562324).