### PR TITLE
macos: Allow larger install_name entries

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -99,7 +99,9 @@ impl Target {
                     libdir.display()
                 )
             };
-            lines.push(line)
+            lines.push(line);
+            // Enable larger LC_RPATH and install_name entries
+            lines.push("-Wl,-headerpad_max_install_names".to_string());
         } else if os == "windows" && env == "gnu" {
             // This is only set up to work on GNU toolchain versions of Rust
             lines.push(format!(


### PR DESCRIPTION
This is needed to be able to add multiple RPATH entries, and also to change the install_name itself. This is enabled by default in Meson.