### PR TITLE
Fix `--dlltool` CLI argument

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1129,7 +1129,7 @@ pub fn cbuild(
                 // dlltool argument overwrites environment var
                 if args.contains_id("dlltool") {
                     dlltool = args
-                        .get_one::<String>("dlltool")
+                        .get_one::<PathBuf>("dlltool")
                         .map(PathBuf::from)
                         .unwrap();
                 }


### PR DESCRIPTION
Regressed since commit 4c500de6b567a1461ffdecdfa746b8901194a68c.

---
```
thread 'main' panicked at 'Mismatch between definition and access of `dlltool`. Could not downcast to TypeId { t: 15851485895063072644 }, need to downcast to TypeId { t: 9487802126495571184 }
', /home/kleisauke/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.2.1/src/parser/error.rs:30:9
```