### PR TITLE
Add a library.import_library configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ versioning = false
 # Add `-Cpanic=abort` to the RUSTFLAGS automatically, it may be useful in case
 # something might panic in the crates used by the library.
 rustflags = "-Cpanic=abort"
+# Used to disable the generation of additional import library file in platforms
+# that have the concept such as Windows
+import_library = false
 ```
 
 ### Custom data install

--- a/src/install.rs
+++ b/src/install.rs
@@ -255,13 +255,14 @@ pub fn cinstall(ws: &Workspace, packages: &[CPackage]) -> anyhow::Result<()> {
                         // We assume they are plugins, install them in the custom libdir path
                         copy(shared_lib, install_path_lib.join(lib_name))?;
                     }
-
-                    let impl_lib = build_targets.impl_lib.as_ref().unwrap();
-                    let impl_lib_name = impl_lib.file_name().unwrap();
-                    copy(impl_lib, install_path_lib.join(impl_lib_name))?;
-                    let def = build_targets.def.as_ref().unwrap();
-                    let def_name = def.file_name().unwrap();
-                    copy(def, install_path_lib.join(def_name))?;
+                    if capi_config.library.import_library {
+                        let impl_lib = build_targets.impl_lib.as_ref().unwrap();
+                        let impl_lib_name = impl_lib.file_name().unwrap();
+                        copy(impl_lib, install_path_lib.join(impl_lib_name))?;
+                        let def = build_targets.def.as_ref().unwrap();
+                        let def_name = def.file_name().unwrap();
+                        copy(def, install_path_lib.join(def_name))?;
+                    }
                 }
             }
         }

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -298,6 +298,7 @@ mod test {
                     version: Version::parse("0.1.0").unwrap(),
                     install_subdir: None,
                     versioning: true,
+                    import_library: true,
                     rustflags: Vec::default(),
                 },
                 install: Default::default(),


### PR DESCRIPTION
It is used to disable the generation of import_libraries when unnecessary in platforms that need it to link libraries (e.g. Windows).

@sdroege could you please check if it would work for gst?