### PR TITLE
README: add libdovi to Users section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Do **not** pass `RUSTFLAGS` that are managed by cargo through other means, (e.g.
 - [gcode-rs](https://github.com/Michael-F-Bryan/gcode-rs)
 - [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs)
 - [lewton](https://github.com/RustAudio/lewton)
+- [libdovi](https://github.com/quietvoid/dovi_tool/tree/main/dolby_vision#libdovi-c-api)
 - [libimagequant](https://github.com/ImageOptim/libimagequant#building-with-cargo-c)
 - [rav1e](https://github.com/xiph/rav1e)
 - [sled](https://github.com/spacejam/sled/tree/master/bindings/sled-native)


### PR DESCRIPTION
Sometimes used via [mpv](https://github.com/mpv-player/mpv/commit/41ad51bda281) -> libplacebo -> libdovi [![Packaging status](https://repology.org/badge/tiny-repos/libdovi.svg)](https://repology.org/project/libdovi/versions)