### PR TITLE
Add version_suffix_components setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ version = "1.2.3"
 install_subdir = "gstreamer-1.0"
 # Used to disable versioning links when installing the dynamic library
 versioning = false
+# Instead of using semver, select a fixed number of version components for your SONAME version suffix:
+# Setting this to 1 with a version of 0.0.0 allows a suffix of `.so.0`
+# Setting this to 3 always includes the full version in the SONAME (indicate any update is ABI breaking)
+#version_suffix_components = 2
 # Add `-Cpanic=abort` to the RUSTFLAGS automatically, it may be useful in case
 # something might panic in the crates used by the library.
 rustflags = "-Cpanic=abort"

--- a/src/build.rs
+++ b/src/build.rs
@@ -402,35 +402,39 @@ pub struct PkgConfigCApiConfig {
 }
 
 #[derive(Debug)]
+pub enum VersionSuffix {
+    Major,
+    MajorMinor,
+    MajorMinorPatch,
+}
+
+#[derive(Debug)]
 pub struct LibraryCApiConfig {
     pub name: String,
     pub version: Version,
     pub install_subdir: Option<String>,
     pub versioning: bool,
-    pub version_suffix_components: Option<u8>,
+    pub version_suffix_components: Option<VersionSuffix>,
     pub import_library: bool,
     pub rustflags: Vec<String>,
 }
 
 impl LibraryCApiConfig {
-    pub fn sover(&self) -> anyhow::Result<String> {
+    pub fn sover(&self) -> String {
         let major = self.version.major;
         let minor = self.version.minor;
         let patch = self.version.patch;
 
-        let sover = match self.version_suffix_components {
+        match self.version_suffix_components {
             None => match (major, minor, patch) {
                 (0, 0, patch) => format!("0.0.{patch}"),
                 (0, minor, _) => format!("0.{minor}"),
                 (major, _, _) => format!("{major}"),
             },
-            Some(1) => format!("{major}"),
-            Some(2) => format!("{major}.{minor}"),
-            Some(3) => format!("{major}.{minor}.{patch}"),
-            Some(num) => anyhow::bail!("Unexpected number of suffix components: {num}"),
-        };
-
-        Ok(sover)
+            Some(VersionSuffix::Major) => format!("{major}"),
+            Some(VersionSuffix::MajorMinor) => format!("{major}.{minor}"),
+            Some(VersionSuffix::MajorMinorPatch) => format!("{major}.{minor}.{patch}"),
+        }
     }
 }
 
@@ -666,10 +670,12 @@ fn load_manifest_capi_config(pkg: &Package) -> anyhow::Result<CApiConfig> {
             let value = value.as_integer().with_context(|| {
                 format!("Value for `version_suffix_components` is not an integer: {value:?}")
             })?;
-            let value = value
-                .try_into()
-                .with_context(|| format!("Value is too large: {value:?}"))?;
-            version_suffix_components = Some(value);
+            version_suffix_components = Some(match value {
+                1 => VersionSuffix::Major,
+                2 => VersionSuffix::MajorMinor,
+                3 => VersionSuffix::MajorMinorPatch,
+                _ => anyhow::bail!("Out of range value for version suffix components: {value}"),
+            });
         }
 
         import_library = library
@@ -923,7 +929,7 @@ fn compile_with_exec(
         let pkg_rustflags = &capi_config.library.rustflags;
 
         let mut leaf_args: Vec<String> = rustc_target
-            .shared_object_link_args(&capi_config, &install_paths.libdir, root_output)?
+            .shared_object_link_args(&capi_config, &install_paths.libdir, root_output)
             .into_iter()
             .flat_map(|l| vec!["-C".to_string(), format!("link-arg={l}")])
             .collect();
@@ -1304,45 +1310,45 @@ mod tests {
     #[test]
     pub fn test_semver_zero_zero_zero() {
         let library = make_test_library_config("0.0.0");
-        let sover = library.sover().unwrap();
+        let sover = library.sover();
         assert_eq!(sover, "0.0.0");
     }
 
     #[test]
     pub fn test_semver_zero_one_zero() {
         let library = make_test_library_config("0.1.0");
-        let sover = library.sover().unwrap();
+        let sover = library.sover();
         assert_eq!(sover, "0.1");
     }
 
     #[test]
     pub fn test_semver_one_zero_zero() {
         let library = make_test_library_config("1.0.0");
-        let sover = library.sover().unwrap();
+        let sover = library.sover();
         assert_eq!(sover, "1");
     }
 
     #[test]
     pub fn text_one_fixed_zero_zero_zero() {
         let mut library = make_test_library_config("0.0.0");
-        library.version_suffix_components = Some(1);
-        let sover = library.sover().unwrap();
+        library.version_suffix_components = Some(VersionSuffix::Major);
+        let sover = library.sover();
         assert_eq!(sover, "0");
     }
 
     #[test]
     pub fn text_two_fixed_one_zero_zero() {
         let mut library = make_test_library_config("1.0.0");
-        library.version_suffix_components = Some(2);
-        let sover = library.sover().unwrap();
+        library.version_suffix_components = Some(VersionSuffix::MajorMinor);
+        let sover = library.sover();
         assert_eq!(sover, "1.0");
     }
 
     #[test]
     pub fn text_three_fixed_one_zero_zero() {
         let mut library = make_test_library_config("1.0.0");
-        library.version_suffix_components = Some(3);
-        let sover = library.sover().unwrap();
+        library.version_suffix_components = Some(VersionSuffix::MajorMinorPatch);
+        let sover = library.sover();
         assert_eq!(sover, "1.0.0");
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -105,13 +105,10 @@ pub(crate) struct UnixLibNames {
 }
 
 impl UnixLibNames {
-    pub(crate) fn new(
-        lib_type: LibType,
-        library: &LibraryCApiConfig,
-    ) -> anyhow::Result<Option<Self>> {
+    pub(crate) fn new(lib_type: LibType, library: &LibraryCApiConfig) -> Option<Self> {
         let lib_name = &library.name;
         let lib_version = &library.version;
-        let main_version = library.sover()?;
+        let main_version = library.sover();
 
         match lib_type {
             LibType::So => {
@@ -122,11 +119,11 @@ impl UnixLibNames {
                 );
                 let lib_with_main_ver = format!("{}.{}", lib, main_version);
 
-                Ok(Some(Self {
+                Some(Self {
                     canonical: lib,
                     with_main_ver: lib_with_main_ver,
                     with_full_ver: lib_with_full_ver,
-                }))
+                })
             }
             LibType::Dylib => {
                 let lib = format!("lib{lib_name}.dylib");
@@ -136,13 +133,13 @@ impl UnixLibNames {
                     "lib{}.{}.{}.{}.dylib",
                     lib_name, lib_version.major, lib_version.minor, lib_version.patch
                 );
-                Ok(Some(Self {
+                Some(Self {
                     canonical: lib,
                     with_main_ver: lib_with_main_ver,
                     with_full_ver: lib_with_full_ver,
-                }))
+                })
             }
-            LibType::Windows => Ok(None),
+            LibType::Windows => None,
         }
     }
 
@@ -242,7 +239,7 @@ pub fn cinstall(ws: &Workspace, packages: &[CPackage]) -> anyhow::Result<()> {
             let lib_type = LibType::from_build_targets(build_targets);
             match lib_type {
                 LibType::So | LibType::Dylib => {
-                    let lib = UnixLibNames::new(lib_type, &capi_config.library)?.unwrap();
+                    let lib = UnixLibNames::new(lib_type, &capi_config.library).unwrap();
                     lib.install(capi_config, shared_lib, &install_path_lib)?;
                 }
                 LibType::Windows => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,18 +5,3 @@ pub mod config;
 pub mod install;
 pub mod pkg_config_gen;
 pub mod target;
-
-trait VersionExt {
-    /// build the main version string
-    fn main_version(&self) -> String;
-}
-
-impl VersionExt for semver::Version {
-    fn main_version(&self) -> String {
-        match (self.major, self.minor, self.patch) {
-            (0, 0, patch) => format!("0.0.{patch}"),
-            (0, minor, _) => format!("0.{minor}"),
-            (major, _, _) => format!("{major}"),
-        }
-    }
-}

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -298,6 +298,7 @@ mod test {
                     version: Version::parse("0.1.0").unwrap(),
                     install_subdir: None,
                     versioning: true,
+                    version_suffix_components: None,
                     import_library: true,
                     rustflags: Vec::default(),
                 },

--- a/src/target.rs
+++ b/src/target.rs
@@ -56,7 +56,7 @@ impl Target {
         capi_config: &CApiConfig,
         libdir: &Path,
         target_dir: &Path,
-    ) -> anyhow::Result<Vec<String>> {
+    ) -> Vec<String> {
         let mut lines = Vec::new();
 
         let lib_name = &capi_config.library.name;
@@ -69,7 +69,7 @@ impl Target {
         let os = &self.os;
         let env = &self.env;
 
-        let sover = capi_config.library.sover()?;
+        let sover = capi_config.library.sover();
 
         if os == "android" {
             lines.push(format!("-Wl,-soname,lib{lib_name}.so"));
@@ -111,6 +111,6 @@ impl Target {
         // See: https://github.com/emscripten-core/emscripten/blob/3.1.39/emcc.py#L92-L94
         // else if os == "emscripten"
 
-        Ok(lines)
+        lines
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use anyhow::*;
 
 use crate::build::CApiConfig;
-use crate::VersionExt;
 
 /// Split a target string to its components
 ///
@@ -57,7 +56,7 @@ impl Target {
         capi_config: &CApiConfig,
         libdir: &Path,
         target_dir: &Path,
-    ) -> Vec<String> {
+    ) -> anyhow::Result<Vec<String>> {
         let mut lines = Vec::new();
 
         let lib_name = &capi_config.library.name;
@@ -70,7 +69,7 @@ impl Target {
         let os = &self.os;
         let env = &self.env;
 
-        let sover = version.main_version();
+        let sover = capi_config.library.sover()?;
 
         if os == "android" {
             lines.push(format!("-Wl,-soname,lib{lib_name}.so"));
@@ -112,6 +111,6 @@ impl Target {
         // See: https://github.com/emscripten-core/emscripten/blob/3.1.39/emcc.py#L92-L94
         // else if os == "emscripten"
 
-        lines
+        Ok(lines)
     }
 }


### PR DESCRIPTION
Related to #345 (this patch is based on my comment there) and rustls/rustls-ffi/pull/274.

This adds a setting to disable automatic semver SONAMEs and to pick an arbitrary number of components from the version string for the SONAME.

This feature allows two additional use-cases for library developers to pick from:

## `.so.0`, `.so.1`, `.so.2`, ...

For a C-style breaking-change counter use a config like this:

```toml
[package.metadata.capi.library]
name = "imagequant"
version = "0.0.0"
version_suffix_components = 1
```

Increase the major version for every time the ABI is broken:

```toml
[package.metadata.capi.library]
name = "imagequant"
version = "1.0.0"
version_suffix_components = 1
```

This pattern is already supported, but one has to start at `.so.1` because it's currently not possible to configure `.so.0`.

Doing this does not interfer with pkg-config metadata:

```
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: imagequant
Description: Convert 24/32-bit images to 8-bit palette with alpha channel.
Version: 4.0.4
Libs: -L${libdir} -limagequant
Cflags: -I${includedir}
Libs.private:  -lgcc_s -lutil -lrt -lpthread -lm -ldl -lc
```

## Opt-out of a stable ABI

To read the version from `[package.version]` but opt-out of a stable ABI:

```toml
[package.metadata.capi.library]
name = "rustls"
version_suffix_components = 3
rustflags = "-Cmetadata=rustls-ffi"
```

"Why not do static linking at this point?" - doing it like this has 3 effects:

- Binary code is available from a single shared object in the dynamic linking ecosystem and does not need to be duplicated into every consuming executable
- Binary code can be centrally security patched by downstream instead of having to replace embedded copies in every consuming executable
- For every new upstream release, all consuming executables need to be rebuilt because the SONAME is always going to change, intentionally preventing the new binary code to be loaded by an executable that assumes the ABI of a previous version

Another way of opting out of a stable ABI is "use 0.1.0 and only ever bump the minor version". cargo-c default settings would then make sure every release is in it's own `libfoo.so.0.1`, `libfoo.so.0.2` SONAME namespace, until comfortable with making ABI compatible `0.X.{patch}` releases that still provide the first two effects, but do not require a rebuild of consuming executables.

---

I originally named this setting `suffix_components` but I'm indecisive which name is better.

As far as I can tell this is the last feature needed to close #345 as completed.

cc: @lu-zero @cpu @kornelski @kyrias