### PR TITLE
Implement Meson parity

### DIFF
--- a/.github/workflows/example-project.yml
+++ b/.github/workflows/example-project.yml
@@ -61,11 +61,19 @@ jobs:
           sudo cp -r temp/usr/local/* /usr/local/
 
       - name: Test pkg-config
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'macos')
         run: |
           set -x
           test "$(pkg-config --cflags example_project)" = "-I/usr/local/include/example-project-0.1"
           test "$(pkg-config --libs example_project)" = "-L/usr/local/lib -lexample-project"
+
+      - name: Test pkg-config
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          set -x
+          ARCHDIR=`dpkg-architecture -qDEB_HOST_MULTIARCH`
+          test "$(pkg-config --cflags example_project)" = "-I/usr/local/include/example-project-0.1"
+          test "$(pkg-config --libs example_project)" = "-L/usr/local/lib/${ARCHDIR} -lexample-project"
 
       - name: Update dynamic linker cache
         if: startsWith(matrix.os, 'ubuntu')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo = "0.79.0"
 cargo-util = "0.2"
 semver = "1.0.3"
 log = "0.4"
-clap = { version="4.0.29", features=["color", "derive", "cargo"] }
+clap = { version = "4.0.29", features = ["color", "derive", "cargo", "string"] }
 regex = "1.5.6"
 cbindgen = { version="0.26.0", default-features=false }
 toml = "0.8"

--- a/src/build.rs
+++ b/src/build.rs
@@ -1049,15 +1049,15 @@ pub fn cbuild(
 ) -> anyhow::Result<(Vec<CPackage>, CompileOptions)> {
     let rustc = config.load_global_rustc(Some(ws))?;
     let targets = args.targets()?;
-    let target = match targets.len() {
-        0 => rustc.host.to_string(),
-        1 => targets[0].to_string(),
+    let (target, is_target_overridden) = match targets.len() {
+        0 => (rustc.host.to_string(), false),
+        1 => (targets[0].to_string(), true),
         _ => {
             anyhow::bail!("Multiple targets not supported yet");
         }
     };
 
-    let rustc_target = target::Target::new(&target)?;
+    let rustc_target = target::Target::new(&target, is_target_overridden)?;
 
     let default_kind = || match (rustc_target.os.as_str(), rustc_target.env.as_str()) {
         ("none", _) | (_, "musl") => vec!["staticlib"],

--- a/src/build.rs
+++ b/src/build.rs
@@ -1223,6 +1223,12 @@ pub fn cbuild(
                 ) {
                     copy(from_shared_lib, to_shared_lib)?;
                 }
+                if let (Some(from_debug_info), Some(to_debug_info)) = (
+                    from_build_targets.debug_info.as_ref(),
+                    build_targets.debug_info.as_ref(),
+                ) {
+                    copy(from_debug_info, to_debug_info)?;
+                }
             }
 
             cpkg.finger_print.static_libs = static_libs;

--- a/src/build.rs
+++ b/src/build.rs
@@ -928,7 +928,7 @@ fn compile_with_exec(
         let pkg = &unit.pkg;
         let capi_config = load_manifest_capi_config(pkg, rustc_target)?;
         let name = &capi_config.library.name;
-        let install_paths = InstallPaths::new(name, args, &capi_config);
+        let install_paths = InstallPaths::new(name, rustc_target, args, &capi_config);
         let pkg_rustflags = &capi_config.library.rustflags;
 
         let mut leaf_args: Vec<String> = rustc_target
@@ -1018,7 +1018,7 @@ impl CPackage {
 
         let name = &capi_config.library.name;
 
-        let install_paths = InstallPaths::new(name, args, &capi_config);
+        let install_paths = InstallPaths::new(name, rustc_target, args, &capi_config);
         let build_targets = BuildTargets::new(
             name,
             rustc_target,
@@ -1057,7 +1057,7 @@ pub fn cbuild(
         }
     };
 
-    let rustc_target = target::Target::new(&target, is_target_overridden)?;
+    let rustc_target = target::Target::new(Some(&target), is_target_overridden)?;
 
     let default_kind = || match (rustc_target.os.as_str(), rustc_target.env.as_str()) {
         ("none", _) | (_, "musl") => vec!["staticlib"],

--- a/src/build.rs
+++ b/src/build.rs
@@ -1019,8 +1019,14 @@ impl CPackage {
         let name = &capi_config.library.name;
 
         let install_paths = InstallPaths::new(name, args, &capi_config);
-        let build_targets =
-            BuildTargets::new(name, rustc_target, root_output, libkinds, &capi_config)?;
+        let build_targets = BuildTargets::new(
+            name,
+            rustc_target,
+            root_output,
+            libkinds,
+            &capi_config,
+            args.get_flag("meson"),
+        )?;
 
         let finger_print = FingerPrint::new(&id, root_output, &build_targets, &install_paths);
 
@@ -1209,6 +1215,7 @@ pub fn cbuild(
                     &root_output,
                     &libkinds,
                     capi_config,
+                    args.get_flag("meson"),
                 )?;
 
                 if let (Some(from_static_lib), Some(to_static_lib)) = (

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,7 @@ struct Common {
     includedir: PathBuf,
     /// Path to directory for installing generated executable files
     #[clap(long = "bindir", default_value = "bin")]
-    bindir: PathBuf,
+    bindir: Option<PathBuf>,
     /// Path to directory for installing generated pkg-config .pc files
     ///
     /// [default: {libdir}/pkgconfig]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,9 @@ struct Common {
     #[clap(long = "crt-static")]
     /// Build the library embedding the C runtime
     crt_static: bool,
+    /// Use the Linux/Meson library naming convention on Windows
+    #[clap(long = "meson-paths", default_value = "false")]
+    meson: bool,
 }
 
 fn base_cli() -> Command {

--- a/src/install.rs
+++ b/src/install.rs
@@ -190,6 +190,7 @@ pub fn cinstall(ws: &Workspace, packages: &[CPackage]) -> anyhow::Result<()> {
             install_path_lib.push(subdir);
         }
 
+        let install_path_bin = append_to_destdir(destdir.as_deref(), &paths.bindir);
         let install_path_lib = append_to_destdir(destdir.as_deref(), &install_path_lib);
         let install_path_pc = append_to_destdir(destdir.as_deref(), &paths.pkgconfigdir);
         let install_path_include = append_to_destdir(destdir.as_deref(), &paths.includedir);
@@ -262,6 +263,18 @@ pub fn cinstall(ws: &Workspace, packages: &[CPackage]) -> anyhow::Result<()> {
                     }
                 }
             }
+        }
+
+        if let Some(ref debug_info) = build_targets.debug_info {
+            ws.gctx()
+                .shell()
+                .status("Installing", "debugging information")?;
+            let destination_path = build_targets
+                .debug_info_file_name(&install_path_bin, &install_path_lib)
+                .unwrap();
+
+            create_dir_all(destination_path.parent().unwrap())?;
+            copy(debug_info, destination_path)?;
         }
     }
 


### PR DESCRIPTION
Hi @lu-zero,

This PR tries to implement the necessary bits to support the following Meson conventions:

- autodetection of `libdir` under Debian distros
- installation of PDB symbols under MSVC
- calling static libraries `libfoo.a` and import libraries `foo.lib` under MSVC

The second item is done in a way that allows adding support for other OSes (as what's needed is passing `-C split-debuginfo=packed`, and this is the default on macOS).

Setting it as draft before testing; will do so later next week, but I wanted to get some early feedback first.

cc @nirbheek 

Fixes #279 
Fixes #280 
Fixes #317 