### PR TITLE
Add visionOS support

### DIFF
--- a/src/build_targets.rs
+++ b/src/build_targets.rs
@@ -96,7 +96,7 @@ impl BuildTargets {
                 let shared_lib = targetdir.join(format!("lib{lib_name}.so"));
                 (shared_lib, static_lib, None, None, None)
             }
-            ("macos", _) | ("ios", _) | ("tvos", _) => {
+            ("macos", _) | ("ios", _) | ("tvos", _) | ("visionos", _) => {
                 let static_lib = targetdir.join(format!("lib{lib_name}.a"));
                 let shared_lib = targetdir.join(format!("lib{lib_name}.dylib"));
                 (shared_lib, static_lib, None, None, None)

--- a/src/install.rs
+++ b/src/install.rs
@@ -92,7 +92,7 @@ impl LibType {
             | ("haiku", _)
             | ("illumos", _)
             | ("emscripten", _) => LibType::So,
-            ("macos", _) | ("ios", _) | ("tvos", _) => LibType::Dylib,
+            ("macos", _) | ("ios", _) | ("tvos", _) | ("visionos", _) => LibType::Dylib,
             ("windows", _) => LibType::Windows,
             _ => unimplemented!("The target {}-{} is not supported yet", os, env),
         }

--- a/src/target.rs
+++ b/src/target.rs
@@ -93,7 +93,7 @@ impl Target {
             } else {
                 format!("-Wl,-soname,lib{lib_name}.so")
             });
-        } else if os == "macos" || os == "ios" || os == "tvos" {
+        } else if os == "macos" || os == "ios" || os == "tvos" || os == "visionos" {
             let line = if capi_config.library.versioning {
                 format!("-Wl,-install_name,{1}/lib{0}.{5}.dylib,-current_version,{2}.{3}.{4},-compatibility_version,{5}",
                         lib_name, libdir.display(), major, minor, patch, sover)


### PR DESCRIPTION
Rust has provided support for visionOS on  [Tier 3](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-visionos.html) and published on v1.79.0. Has tested build [libdovi](https://github.com/quietvoid/dovi_tool/tree/main/dolby_vision).