### PR TITLE
Update cbindgen dependency to version 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ semver = "1.0.3"
 log = "0.4"
 clap = { version = "4.0.29", features = ["color", "derive", "cargo", "string"] }
 regex = "1.5.6"
-cbindgen = { version="0.26.0", default-features=false }
+cbindgen = { version="0.27.0", default-features=false }
 toml = "0.8"
 serde = "1.0.123"
 serde_derive = "1.0"


### PR DESCRIPTION
Recently released: https://github.com/mozilla/cbindgen/releases/tag/v0.27.0
It allows support for using C-string literals, coming from `syn` update.

I'm not sure if anything else needs checking, it builds and passes the tests.