### PR TITLE
Handle unwrap when link line is empty, i.e. nostd crates.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1158,7 +1158,7 @@ pub fn cbuild(
                     .unwrap()
                     .values()
                     .next()
-                    .unwrap()
+                    .map_or("", |s| s)
                     .to_string()
             };
             let capi_config = &cpkg.capi_config;


### PR DESCRIPTION
A terribly tiny PR to follow up on [#394](https://github.com/lu-zero/cargo-c/issues/394)

This works for my no-std package, and the coverage script still passes. If there's anything else needed just let me know!