### PR TITLE
Use the `object` crate to generate `.def` files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ anyhow = "1.0"
 cc = "1.0"
 glob = "0.3"
 itertools = "0.13"
+object = "0.36.4"
 
 # workaround cargo
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
These files are relatively simple, and using a rust library rather than an external shell command is convenient for testing and cross-compilation. I also suspect that for integrating into cargo/rustc, calling an external binary won't be accepted.

Is this logic exercised by CI? If not I could add an example `.dll` and test that it generates the expected `.def` file.