### PR TITLE
Generate import libraries without `Command`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ cc = "1.0"
 glob = "0.3"
 itertools = "0.13"
 object = "0.36.4"
+implib = "0.3.2"
 
 # workaround cargo
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ anyhow = "1.0"
 cc = "1.0"
 glob = "0.3"
 itertools = "0.13"
+object = "0.36.4"
 
 # workaround cargo
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
Gets rid of two more nasty `Command` invocations. This'll need a rebase once https://github.com/lu-zero/cargo-c/pull/402 is merged, but we can handle any review comments already. 

This time the logic is effectively untested by me, and would really benefit from the CI improvements suggested in the other PR.