### PR TITLE
reduce the number of feature flags enabled for `object`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ anyhow = "1.0"
 cc = "1.0"
 glob = "0.3"
 itertools = "0.13"
-object = "0.36.4"
-implib = "0.3.2"
+implib = "0.3.3"
+object = { version = "0.36.4", default-features = false, features = ["std", "read_core", "pe"] }
 
 # workaround cargo
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
also sets the version to the version used by `implib`, so `object` does not get built twice