### PR TITLE
pkg-config: Use the right link-line when generating pkg-config files

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1177,7 +1177,7 @@ pub fn cbuild(
             let name = &cpkg.capi_config.library.name;
             let (pkg_config_static_libs, static_libs) = if library_types.only_cdylib() {
                 (String::new(), String::new())
-            } else if let Some(libs) = exec.link_line.lock().unwrap().values().next() {
+            } else if let Some(libs) = exec.link_line.lock().unwrap().get(&cpkg.finger_print.id) {
                 (static_libraries(libs, &rustc_target), libs.to_string())
             } else {
                 (String::new(), String::new())


### PR DESCRIPTION
We were always using the first package link line, leading to broken pkg-config files.

For example in
https://gitlab.freedesktop.org/thiblahute/gst-plugins-rs/-/jobs/64909911, we can see that static linking using that `.pc` file doesn't work as it is not linking to `stdc++` in that specific case.