### PR TITLE
Fix Meson naming convention

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -174,6 +174,7 @@ fn write_def_file<W: std::io::Write>(
 /// Build import library for windows-gnu
 fn build_implib_file(
     ws: &Workspace,
+    build_targets: &BuildTargets,
     name: &str,
     target: &target::Target,
     targetdir: &Path,
@@ -201,10 +202,7 @@ fn build_implib_file(
             }
         };
 
-        let lib_path = match flavor {
-            Flavor::Msvc => targetdir.join(format!("{name}.dll.lib")),
-            Flavor::Gnu => targetdir.join(format!("{name}.dll.a")),
-        };
+        let lib_path = build_targets.impl_lib.as_ref().unwrap();
 
         let lib_file = cargo_util::paths::create(lib_path)?;
         write_implib(lib_file, machine_type, flavor, &def_contents)?;
@@ -1200,7 +1198,7 @@ pub fn cbuild(
             if !library_types.only_staticlib() && capi_config.library.import_library {
                 let lib_name = name;
                 build_def_file(ws, lib_name, &rustc_target, &root_output)?;
-                build_implib_file(ws, lib_name, &rustc_target, &root_output)?;
+                build_implib_file(ws, build_targets, lib_name, &rustc_target, &root_output)?;
             }
 
             if capi_config.header.enabled {

--- a/src/build_targets.rs
+++ b/src/build_targets.rs
@@ -129,10 +129,18 @@ impl BuildTargets {
     }
 
     pub fn shared_output_file_name(&self) -> Option<OsString> {
-        if self.shared_lib.is_some() && self.use_meson_naming_convention {
-            Some(format!("lib{}.dll", self.name).into())
-        } else {
-            Some(self.shared_lib.as_ref()?.file_name().unwrap().to_owned())
+        match self.lib_type() {
+            LibType::Windows => {
+                if self.shared_lib.is_some()
+                    && self.use_meson_naming_convention
+                    && self.target.env == "gnu"
+                {
+                    Some(format!("lib{}.dll", self.name).into())
+                } else {
+                    Some(self.shared_lib.as_ref()?.file_name()?.to_owned())
+                }
+            }
+            _ => Some(self.shared_lib.as_ref()?.file_name()?.to_owned()),
         }
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -270,11 +270,7 @@ pub fn cinstall(ws: &Workspace, packages: &[CPackage]) -> anyhow::Result<()> {
                     }
                     if capi_config.library.import_library {
                         let impl_lib = build_targets.impl_lib.as_ref().unwrap();
-                        let impl_lib_name = if build_targets.use_meson_naming_convention {
-                            format!("{}.lib", build_targets.name).into()
-                        } else {
-                            impl_lib.file_name().unwrap().to_owned()
-                        };
+                        let impl_lib_name = impl_lib.file_name().unwrap();
                         copy(ws, impl_lib, install_path_lib.join(impl_lib_name))?;
                         let def = build_targets.def.as_ref().unwrap();
                         let def_name = def.file_name().unwrap();


### PR DESCRIPTION
This PR fixes two issues when using `--meson-paths`.

- Ensure import libraries under MinGW are named `libfoo.dll.a` (44e96dcd46a6e2385e328d1bc914707b4c04a8c9).
  ```diff
  @@ -4,5 +4,5 @@
        Copying /tmp/rav1e/x86_64-pc-windows-gnullvm/release/rav1e.h to /usr/x86_64-w64-mingw32/include/rav1e/rav1e.h
     Installing shared library
        Copying /tmp/rav1e/x86_64-pc-windows-gnullvm/release/rav1e.dll to /usr/x86_64-w64-mingw32/bin/librav1e.dll
  -     Copying /tmp/rav1e/x86_64-pc-windows-gnullvm/release/rav1e.dll.a to /usr/x86_64-w64-mingw32/lib/rav1e.lib
  +     Copying /tmp/rav1e/x86_64-pc-windows-gnullvm/release/librav1e.dll.a to /usr/x86_64-w64-mingw32/lib/librav1e.dll.a
        Copying /tmp/rav1e/x86_64-pc-windows-gnullvm/release/rav1e.def to /usr/x86_64-w64-mingw32/lib/rav1e.def
  ```
- Shared libraries under MSVC are always in the form `foo.dll` (9cf2de8126d9705cb78b3545ebed84d0e5c625d8).
  ```diff
  @@ -3,7 +3,7 @@
     Installing header file
        Copying C:\Users\kleisauke\rav1e\target\x86_64-pc-windows-msvc\release\rav1e.h to C:\include\rav1e\rav1e.h
     Installing shared library
  -     Copying C:\Users\kleisauke\rav1e\target\x86_64-pc-windows-msvc\release\rav1e.dll to C:\bin\librav1e.dll
  +     Copying C:\Users\kleisauke\rav1e\target\x86_64-pc-windows-msvc\release\rav1e.dll to C:\bin\rav1e.dll
        Copying C:\Users\kleisauke\rav1e\target\x86_64-pc-windows-msvc\release\rav1e.lib to C:\lib\rav1e.lib
        Copying C:\Users\kleisauke\rav1e\target\x86_64-pc-windows-msvc\release\rav1e.def to C:\lib\rav1e.def
     Installing debugging information
  ```

/cc @amyspark


As an aside, I've encountered the same issue as #426 with the `x86_64-pc-windows-gnullvm` target. It looks like `-Wl,--output-def` here:
https://github.com/lu-zero/cargo-c/blob/c4e6c08da0c9a12d16b1e00666e5ce67e3d013a9/src/target.rs#L112-L118
also generates a `.def` file with a missing library name, at least on LLVM (I haven't checked Binutils):
https://github.com/llvm/llvm-project/blob/llvmorg-19.1.6/lld/COFF/MinGW.cpp#L173-L192

Perhaps we could somehow allow `implib` to override the import library name?:
https://github.com/messense/implib-rs/blob/v0.3.3/src/lib.rs#L109-L112