### PR TITLE
Fix import lib generation under MinGW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ anyhow = "1.0"
 cc = "1.0"
 glob = "0.3"
 itertools = "0.14"
-implib = "0.3.3"
+implib = "0.3.4"
 object = { version = "0.36.4", default-features = false, features = ["std", "read_core", "pe"] }
 
 [features]


### PR DESCRIPTION
Override `import_name` after parsing the `.def` file, as `-Wl,--output-def,` in LLVM and Binutils does not include a library name in the generated `.def` file.
https://github.com/lu-zero/cargo-c/blob/c37aec4d53076c3198c38e3d2cf187e35e199d95/src/target.rs#L112-L118
https://github.com/llvm/llvm-project/blob/llvmorg-19.1.6/lld/COFF/MinGW.cpp#L173-L192
https://github.com/bminor/binutils-gdb/blob/binutils-2_43_1/binutils/dlltool.c#L1813-L1872

Also bump `implib` while we are here, to ensure the import library works when targeting `i686-pc-windows-gnu{,llvm}`.