### PR TITLE
Bump Cargo to 0.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-c"
-version = "0.10.11+cargo-0.86.0"
+version = "0.10.12+cargo-0.87.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 description = "Helper program to build and install c-like libraries"
 license = "MIT"
@@ -28,7 +28,7 @@ name = "cargo-ctest"
 path = "src/bin/ctest.rs"
 
 [dependencies]
-cargo = "0.86.0"
+cargo = "0.87.0"
 cargo-util = "0.2"
 semver = "1.0.3"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/lu-zero/cargo-c"
 categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 keywords = ["cargo", "cdylib"]
-rust-version = "1.83"
+rust-version = "1.84"
 
 [[bin]]
 name = "cargo-capi"


### PR DESCRIPTION
👋🏻 

I noticed some `cargo-c` install failures in CI this morning and noticed that Cargo `0.87.0` dropped several hours ago: https://github.com/rust-lang/cargo/releases/tag/0.87.0

I bumped this locally and `cargo-c` installed without issue, but let me know if there are any other changes/considerations needed here.

With the current release on both Rust 1.86.0 and 1.85.1:
```
Installing cargo-c v0.10.11+cargo-0.86.0 (/Users/.../repos/upstream/cargo-c)
    Updating crates.io index
     Locking 377 packages to latest compatible versions
      Adding cargo v0.86.0 (available: v0.87.0)
...
error[E0277]: `std::option::Option<PackageName>` doesn't implement `std::fmt::Display`
   --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/targets.rs:120:13
    |
120 |             package.name
    |             ^^^^^^^^^^^^ `std::option::Option<PackageName>` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `std::option::Option<PackageName>`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
   --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:334:13
    |
331 |         normalized_toml.lib = targets::normalize_lib(
    |                               ---------------------- arguments to this function are incorrect
...
334 |             &original_package.name,
    |             ^^^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `&Option<PackageName>`
    |
    = note: expected reference `&str`
               found reference `&std::option::Option<PackageName>`
note: function defined here
   --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/targets.rs:128:8
    |
128 | pub fn normalize_lib(
    |        ^^^^^^^^^^^^^
...
131 |     package_name: &str,
    |     ------------------

error[E0308]: mismatched types
   --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:342:13
    |
339 |         normalized_toml.bin = Some(targets::normalize_bins(
    |                                    ----------------------- arguments to this function are incorrect
...
342 |             &original_package.name,
    |             ^^^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `&Option<PackageName>`
    |
    = note: expected reference `&str`
               found reference `&std::option::Option<PackageName>`
note: function defined here
   --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/targets.rs:256:8
    |
256 | pub fn normalize_bins(
    |        ^^^^^^^^^^^^^^
...
259 |     package_name: &str,
    |     ------------------

error[E0308]: mismatched types
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:389:13
     |
385  |         deprecated_underscore(
     |         --------------------- arguments to this function are incorrect
...
389  |             package_name,
     |             ^^^^^^^^^^^^ expected `&str`, found `&Option<PackageName>`
     |
     = note: expected reference `&str`
                found reference `&std::option::Option<PackageName>`
note: function defined here
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:2596:4
     |
2596 | fn deprecated_underscore<T>(
     |    ^^^^^^^^^^^^^^^^^^^^^
...
2600 |     name: &str,
     |     ----------

error[E0308]: mismatched types
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:409:13
     |
405  |         deprecated_underscore(
     |         --------------------- arguments to this function are incorrect
...
409  |             package_name,
     |             ^^^^^^^^^^^^ expected `&str`, found `&Option<PackageName>`
     |
     = note: expected reference `&str`
                found reference `&std::option::Option<PackageName>`
note: function defined here
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:2596:4
     |
2596 | fn deprecated_underscore<T>(
     |    ^^^^^^^^^^^^^^^^^^^^^
...
2600 |     name: &str,
     |     ----------

error[E0599]: no method named `contains` found for reference `&std::option::Option<PackageName>` in the current scope
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:1143:21
     |
1143 |     if package_name.contains(':') {
     |                     ^^^^^^^^ `&std::option::Option<PackageName>` is not an iterator
     |
help: call `.into_iter()` first
     |
1143 |     if package_name.into_iter().contains(':') {
     |                     ++++++++++++

error[E0599]: no method named `as_str` found for enum `std::option::Option` in the current scope
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/mod.rs:1482:33
     |
1482 |         normalized_package.name.as_str().into(),
     |                                 ^^^^^^ method not found in `Option<PackageName>`
     |
note: the method `as_str` exists on the type `PackageName`
    --> /Users/.../.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/string.rs:1081:5
     |
1081 |     pub const fn as_str(&self) -> &str {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: consider using `Option::expect` to unwrap the `PackageName` value, panicking if the value is an `Option::None`
     |
1482 |         normalized_package.name.expect("REASON").as_str().into(),
     |                                +++++++++++++++++

Some errors have detailed explanations: E0277, E0308, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `cargo` (lib) due to 7 previous errors
error: failed to compile `cargo-c v0.10.11+cargo-0.86.0 (/Users/.../repos/upstream/cargo-c)`, intermediate artifacts can be found at `/Users/.../repos/upstream/cargo-c/target`.
```

Thanks!

cc: @lu-zero 

Edit: use https://github.com/lu-zero/cargo-c/pull/453#issuecomment-2777629450 as a workaround for the time being 🙂