### PR TITLE
Always allow building cdylibs on musl

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1033,7 +1033,7 @@ impl LibraryTypes {
         // - https://github.com/lu-zero/cargo-c/issues/180
         Self {
             staticlib: true,
-            cdylib: target.os != "none" && target.env != "musl",
+            cdylib: target.os != "none",
         }
     }
 


### PR DESCRIPTION
Building cdylibs can only work on musl when the CRT is not statically linked: `RUSTFLAGS="-C target-feature=-crt-static"` however we have no way to detect that case.

It's better to always allow it, and let the user find the "troubleshooting" section of cargo-c when they encounter an error.

In nightly rust, we can detect this case and we can add it once it's in stable.

Fixes https://github.com/lu-zero/cargo-c/issues/458