### PR TITLE
Fix non-POSIX paths in Libdir under Windows

### DIFF
--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -111,7 +111,7 @@ impl PkgConfig {
         }
 
         let libs = vec![
-            format!("-L{}", libdir.display()),
+            format!("-L{}", canonicalize(libdir.display().to_string())),
             format!("-l{}", capi_config.library.name),
         ];
 


### PR DESCRIPTION
Hi @lu-zero ,

This fixes using the GStreamer plugins .pc files with e.g. CMake, which interprets backslashes as an escape code and strips them automatically.

This is an upstream fix for the following GStreamer MR: https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1895

cc @nirbheek