### PR TITLE
Allow disabling emission of library version constants in header files

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ generation = true
 # Can be use to disable header generation completely.
 # This can be used when generating dynamic modules instead of an actual library.
 enabled = true
+# Whether to emit library version constants (e.g. `FOO_MAJOR`, `FOO_MINOR` and
+# `FOO_PATCH`) at the top of the header file. Enabled by default.
+emit_version_constants = true
 ```
 
 ### `pkg-config` File Generation

--- a/src/build.rs
+++ b/src/build.rs
@@ -29,7 +29,7 @@ use crate::target;
 fn build_include_file(
     ws: &Workspace,
     name: &str,
-    version: &Version,
+    version: Option<&Version>,
     root_output: &Path,
     root_path: &Path,
 ) -> anyhow::Result<()> {
@@ -43,15 +43,17 @@ fn build_include_file(
 
     // TODO: map the errors
     let mut config = cbindgen::Config::from_root_or_default(crate_path);
-    let warning = config.autogen_warning.unwrap_or_default();
-    let version_info = format!(
-        "\n#define {0}_MAJOR {1}\n#define {0}_MINOR {2}\n#define {0}_PATCH {3}\n",
-        name.to_uppercase().replace('-', "_"),
-        version.major,
-        version.minor,
-        version.patch
-    );
-    config.autogen_warning = Some(warning + &version_info);
+    if let Some(version) = version {
+        let warning = config.autogen_warning.unwrap_or_default();
+        let version_info = format!(
+            "\n#define {0}_MAJOR {1}\n#define {0}_MINOR {2}\n#define {0}_PATCH {3}\n",
+            name.to_uppercase().replace('-', "_"),
+            version.major,
+            version.minor,
+            version.patch
+        );
+        config.autogen_warning = Some(warning + &version_info);
+    }
     cbindgen::Builder::new()
         .with_crate(crate_path)
         .with_config(config)
@@ -343,6 +345,7 @@ pub struct HeaderCApiConfig {
     pub subdirectory: String,
     pub generation: bool,
     pub enabled: bool,
+    pub emit_version_constants: bool,
 }
 
 #[derive(Debug, Hash)]
@@ -540,6 +543,11 @@ fn load_manifest_capi_config(
                 .and_then(|h| h.get("enabled"))
                 .map(|v| v.clone().try_into())
                 .unwrap_or(Ok(true))?,
+            emit_version_constants: header
+                .as_ref()
+                .and_then(|h| h.get("emit_version_constants"))
+                .map(|v| v.clone().try_into())
+                .unwrap_or(Ok(true))?,
         }
     } else {
         HeaderCApiConfig {
@@ -547,6 +555,7 @@ fn load_manifest_capi_config(
             subdirectory: String::from(name),
             generation: true,
             enabled: true,
+            emit_version_constants: true,
         }
     };
 
@@ -1216,11 +1225,12 @@ pub fn cbuild(
 
             if capi_config.header.enabled {
                 let header_name = &capi_config.header.name;
+                let emit_version_constants = capi_config.header.emit_version_constants;
                 if capi_config.header.generation {
                     build_include_file(
                         ws,
                         header_name,
-                        &cpkg.version,
+                        emit_version_constants.then_some(&cpkg.version),
                         &root_output,
                         &cpkg.root_path,
                     )?;

--- a/src/pkg_config_gen.rs
+++ b/src/pkg_config_gen.rs
@@ -282,6 +282,7 @@ mod test {
                     subdirectory: "".into(),
                     generation: true,
                     enabled: true,
+                    emit_version_constants: true,
                 },
                 pkg_config: crate::build::PkgConfigCApiConfig {
                     name: "foo".into(),


### PR DESCRIPTION
Adds a configuration option to disable emitting library version constants (such as `FOO_MAJOR`, `FOO_MINOR` and `FOO_PATCH`) into header files.

Whilst useful in many cases, the existing behaviour means that running cbindgen independently produces different results to running it through cargo-c. It is also unwanted in many cases, such as for internal libraries that are not versioned independently.