### PR TITLE
Fix wrong dylib install name on macOS

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -923,10 +923,11 @@ fn compile_with_exec(
         let capi_config = load_manifest_capi_config(pkg, rustc_target)?;
         let name = &capi_config.library.name;
         let install_paths = InstallPaths::new(name, rustc_target, args, &capi_config);
+        let install_path_lib = install_paths.lib_install_dir(&capi_config);
         let pkg_rustflags = &capi_config.library.rustflags;
 
         let mut leaf_args: Vec<String> = rustc_target
-            .shared_object_link_args(&capi_config, &install_paths.libdir, root_output)
+            .shared_object_link_args(&capi_config, &install_path_lib, root_output)
             .into_iter()
             .flat_map(|l| ["-C".to_string(), format!("link-arg={l}")])
             .collect();

--- a/src/install.rs
+++ b/src/install.rs
@@ -201,13 +201,9 @@ pub fn cinstall(ws: &Workspace, packages: &[CPackage]) -> anyhow::Result<()> {
 
         let destdir = &paths.destdir;
 
-        let mut install_path_lib = paths.libdir.clone();
-        if let Some(subdir) = &capi_config.library.install_subdir {
-            install_path_lib.push(subdir);
-        }
-
         let install_path_bin = append_to_destdir(destdir.as_deref(), &paths.bindir);
-        let install_path_lib = append_to_destdir(destdir.as_deref(), &install_path_lib);
+        let install_path_lib =
+            append_to_destdir(destdir.as_deref(), &paths.lib_install_dir(capi_config));
         let install_path_pc = append_to_destdir(destdir.as_deref(), &paths.pkgconfigdir);
         let install_path_include = append_to_destdir(destdir.as_deref(), &paths.includedir);
         let install_path_data = append_to_destdir(destdir.as_deref(), &paths.datadir);
@@ -357,6 +353,15 @@ fn get_path_or(args: &ArgMatches, id: &str, f: impl FnOnce() -> PathBuf) -> Path
 }
 
 impl InstallPaths {
+    pub fn lib_install_dir(&self, capi_config: &CApiConfig) -> PathBuf {
+        let mut lib_install_dir = self.libdir.clone();
+        if let Some(subdir) = &capi_config.library.install_subdir {
+            lib_install_dir.push(subdir);
+        }
+
+        lib_install_dir
+    }
+
     pub fn new(
         _name: &str,
         rustc_target: &Target,


### PR DESCRIPTION
Fixes https://github.com/lu-zero/cargo-c/issues/532

As mentioned in the issue above, the file would be installed in the correct dir, but its embedded install name would be missing the last subdirectory.